### PR TITLE
🐛 FIX: Configuration and setup fixes

### DIFF
--- a/jupyterbook_latex/__init__.py
+++ b/jupyterbook_latex/__init__.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from docutils import nodes as docnodes
 
-__version__ = "0.1.3"
+__version__ = "0.1.3-alpha"
 """jupyterbook-latex version"""
 
 logger = logging.getLogger(__name__)
@@ -44,15 +44,17 @@ def build_init_handler(app):
                 "Some features of this exetension will work only with a jupyter-book application"  # noqa: E501
             )
             return
+        app.config["myst_amsmath_enable"] = True
+        app.setup_extension("sphinx.ext.imgconverter")
         app.add_transform(LatexMasterDocTransforms)
         app.add_post_transform(ToctreeTransforms)
         app.add_post_transform(handleSubSections)
 
 
 def add_necessary_config(app, config):
+    # only allow latex builder to access rest of the features
     config["latex_engine"] = "xelatex"
     config["latex_theme"] = "jupyterBook"
-    config["myst_amsmath_enable"] = True
     # preamble to overwrite things from sphinx latex writer
     config["latex_elements"] = {
         "preamble": r"""
@@ -96,6 +98,5 @@ def setup(app):
         text=(skip, None),
         man=(skip, None),
     )
-    app.setup_extension("sphinx.ext.imgconverter")
     app.connect("config-inited", add_necessary_config)
     app.connect("builder-inited", build_init_handler)

--- a/jupyterbook_latex/__init__.py
+++ b/jupyterbook_latex/__init__.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from docutils import nodes as docnodes
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 """jupyterbook-latex version"""
 
 logger = logging.getLogger(__name__)

--- a/jupyterbook_latex/__init__.py
+++ b/jupyterbook_latex/__init__.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from docutils import nodes as docnodes
 
-__version__ = "0.1.3-alpha"
+__version__ = "0.1.2"
 """jupyterbook-latex version"""
 
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,14 @@ for line in lines.read_text().split("\n"):
 setup(
     name="jupyterbook-latex",
     version=version,
+    python_requires=">=3.6",
+    author="Executable Book Project",
+    author_email="jupyter@googlegroups.com",
+    url="https://executablebooks.org/",
+    project_urls={
+        "Source": "https://github.com/executablebooks/jupyter-book/",
+        "Tracker": "https://github.com/executablebooks/jupyter-book/issues",
+    },
     description="Latex specific features for jupyter book",
     packages=find_packages(),
     long_description=open("./README.md", "r").read(),
@@ -34,4 +42,5 @@ setup(
             "myst-parser",
         ],
     },
+    include_package_data=True,
 )


### PR DESCRIPTION
The current PR specifically limits the loading of `sphinx.ext.imgconverter` extension, and latex math for latex builder.
and some necessary setup info like `include_package_data`