### PR TITLE
👌 IMPROVE: Supporting math symbols

### DIFF
--- a/jupyterbook_latex/theme/jupyterBook.cls
+++ b/jupyterbook_latex/theme/jupyterBook.cls
@@ -4,6 +4,7 @@
 \RequirePackage{xcolor}
 \RequirePackage[utf8]{inputenc}
 \RequirePackage{graphicx}
+\RequirePackage{amsmath}
 
 \def\sphinxdocclass{report}
 \LoadClass{sphinxmanual}
@@ -11,3 +12,6 @@
 \renewcommand{\normalsize}{\fontsize{9}{10}\selectfont}
 \setlength{\textwidth}{17.5cm}
 \setlength{\textheight}{22cm}
+
+\DeclareMathOperator*{\argmax}{arg\,max}
+\DeclareMathOperator*{\argmin}{arg\,min}

--- a/jupyterbook_latex/theme/jupyterBook.cls
+++ b/jupyterbook_latex/theme/jupyterBook.cls
@@ -5,6 +5,7 @@
 \RequirePackage[utf8]{inputenc}
 \RequirePackage{graphicx}
 \RequirePackage{amsmath}
+\RequirePackage{mathrsfs}
 
 \def\sphinxdocclass{report}
 \LoadClass{sphinxmanual}
@@ -15,3 +16,4 @@
 
 \DeclareMathOperator*{\argmax}{arg\,max}
 \DeclareMathOperator*{\argmin}{arg\,min}
+\DeclareMathOperator*{\gt}{>}


### PR DESCRIPTION
This PR has introduced support for the following math symbols to be used in LaTeX : 

-  \argmin, \argmax 
-  \gt (greater then)
- \mathscr (font styling for math symbols)