### PR TITLE
👌IMPROVE: Removed fontsize from class file

### DIFF
--- a/jupyterbook_latex/__init__.py
+++ b/jupyterbook_latex/__init__.py
@@ -55,16 +55,22 @@ def add_necessary_config(app, config):
     # only allow latex builder to access rest of the features
     config["latex_engine"] = "xelatex"
     config["latex_theme"] = "jupyterBook"
+
     # preamble to overwrite things from sphinx latex writer
-    config["latex_elements"] = {
-        "preamble": r"""
-            \usepackage[Latin,Greek]{ucharclasses}
-            \usepackage{newunicodechar}
-            \newunicodechar{β}{\beta}
-            % fixing title of the toc
-            \addto\captionsenglish{\renewcommand{\contentsname}{Contents}}
+    configPreamble = ""
+    if "preamble" in config["latex_elements"]:
+        configPreamble = config["latex_elements"]["preamble"]
+
+    config["latex_elements"]["preamble"] = (
+        configPreamble
+        + r"""
+         \usepackage[Latin,Greek]{ucharclasses}
+        \usepackage{newunicodechar}
+        \newunicodechar{β}{\beta}
+        % fixing title of the toc
+        \addto\captionsenglish{\renewcommand{\contentsname}{Contents}}
         """
-    }
+    )
 
 
 def copy_static_files(app):

--- a/jupyterbook_latex/theme/jupyterBook.cls
+++ b/jupyterbook_latex/theme/jupyterBook.cls
@@ -10,8 +10,6 @@
 \def\sphinxdocclass{report}
 \LoadClass{sphinxmanual}
 
-
-\renewcommand{\normalsize}{\fontsize{9}{10}\selectfont}
 \setlength{\textwidth}{17.5cm}
 \setlength{\textheight}{22cm}
 


### PR DESCRIPTION
Removing explicit declaration of fontsize in `jupyterBook.cls` file and instead taking the default fontsize of `10pt` specified by sphinx.
GIves freedom to users to specify there own fontsize using `latex_elements`'s `pointsize` key. 

This PR also facilitates users to specify their own preamble without it being overridden by the extension.

fixes https://github.com/executablebooks/jupyterbook-latex/issues/25