### PR TITLE
🐛 FIX: using unicode-math package to handle math characters

### DIFF
--- a/jupyterbook_latex/__init__.py
+++ b/jupyterbook_latex/__init__.py
@@ -65,8 +65,7 @@ def add_necessary_config(app, config):
         configPreamble
         + r"""
          \usepackage[Latin,Greek]{ucharclasses}
-        \usepackage{newunicodechar}
-        \newunicodechar{β}{\beta}
+        \usepackage{unicode-math}
         % fixing title of the toc
         \addto\captionsenglish{\renewcommand{\contentsname}{Contents}}
         """


### PR DESCRIPTION
Also removed unicodechar package with explicit handling of β, as it was affecting β's in code blocks.
Just unicode-math handles β as well

fixes https://github.com/QuantEcon/lecture-python.myst/issues/76