### PR TITLE
🐛 FIX: file extension handling in _toc.yml

### DIFF
--- a/jupyterbook_latex/utils.py
+++ b/jupyterbook_latex/utils.py
@@ -1,9 +1,16 @@
 from pathlib import Path
 
 
-def get_filename(source):
+def getFilename(source):
     name = Path(source).stem
     return name
+
+
+def removeExtension(filename):
+    index = filename.find(".")
+    if index > 0:
+        filename = filename[0:index]
+    return filename
 
 
 def sphinxEncode(string):

--- a/tests/roots/test-partsToc/_toc.yml
+++ b/tests/roots/test-partsToc/_toc.yml
@@ -2,11 +2,11 @@
 
 - part: part1
   chapters:
-  - file: part1/chap1
+  - file: part1/chap1.md
   - file: part1/chap2
     sections:
       - file: part1/sec1
-      - file: part1/sec2
+      - file: part1/sec2.md
 
 - part: part2
   chapters:


### PR DESCRIPTION
Handling having explicit mention of extension in `_toc.yml` file.

fixes https://github.com/executablebooks/jupyterbook-latex/issues/44
fixes https://github.com/executablebooks/jupyterbook-latex/issues/43