### PR TITLE
👌 IMPROVE: Handling relative path of master_doc to populate frontmatter

### DIFF
--- a/jupyterbook_latex/transforms.py
+++ b/jupyterbook_latex/transforms.py
@@ -8,7 +8,7 @@ from sphinx.transforms import SphinxTransform
 from sphinx import addnodes
 from sphinx.builders.latex.nodes import thebibliography
 
-from .utils import getRelativeFilename, removeExtension
+from .utils import getFilenameWithSubpath, removeExtension
 from .nodes import HiddenCellNode, H2Node, H3Node
 
 # Utility functions
@@ -104,8 +104,9 @@ class LatexMasterDocTransforms(SphinxTransform):
 
         # check if the document is the masterdoc
         numbSlashes = self.app.config.master_doc.count("/")
+
         if (
-            getRelativeFilename(self.document["source"], numbSlashes)
+            getFilenameWithSubpath(self.document["source"], numbSlashes)
             == self.app.config.master_doc
         ):
             # pull the toctree-wrapper and append it later to the topmost document level
@@ -126,7 +127,7 @@ class handleSubSections(SphinxPostTransform):
 
     def apply(self, **kwargs: Any) -> None:
         docname = self.document["source"]
-        if getRelativeFilename(docname, 0) == self.app.config.master_doc:
+        if getFilenameWithSubpath(docname, 0) == self.app.config.master_doc:
             for compound in self.document.traverse(docutils.nodes.compound):
                 if "toctree-wrapper" in compound["classes"]:
                     nodecopy = compound
@@ -153,7 +154,7 @@ class ToctreeTransforms(SphinxPostTransform):
             return False
 
         docname = self.document["source"]
-        if getRelativeFilename(docname, 0) == self.app.config.master_doc:
+        if getFilenameWithSubpath(docname, 0) == self.app.config.master_doc:
             TOC_PATH = Path(self.app.confdir).joinpath("_toc.yml")
             tocfile = yaml.safe_load(TOC_PATH.read_text("utf8"))
 

--- a/jupyterbook_latex/transforms.py
+++ b/jupyterbook_latex/transforms.py
@@ -8,7 +8,7 @@ from sphinx.transforms import SphinxTransform
 from sphinx import addnodes
 from sphinx.builders.latex.nodes import thebibliography
 
-from .utils import getFilename, removeExtension
+from .utils import getRelativeFilename, removeExtension
 from .nodes import HiddenCellNode, H2Node, H3Node
 
 # Utility functions
@@ -103,7 +103,11 @@ class LatexMasterDocTransforms(SphinxTransform):
                     replaceWithNode(sect, HiddenCellNode, False)
 
         # check if the document is the masterdoc
-        if getFilename(self.document["source"]) == self.app.config.master_doc:
+        numbSlashes = self.app.config.master_doc.count("/")
+        if (
+            getRelativeFilename(self.document["source"], numbSlashes)
+            == self.app.config.master_doc
+        ):
             # pull the toctree-wrapper and append it later to the topmost document level
             for node in self.document.traverse(docutils.nodes.compound):
                 if "toctree-wrapper" in node["classes"]:
@@ -122,7 +126,7 @@ class handleSubSections(SphinxPostTransform):
 
     def apply(self, **kwargs: Any) -> None:
         docname = self.document["source"]
-        if getFilename(docname) == self.app.config.master_doc:
+        if getRelativeFilename(docname, 0) == self.app.config.master_doc:
             for compound in self.document.traverse(docutils.nodes.compound):
                 if "toctree-wrapper" in compound["classes"]:
                     nodecopy = compound
@@ -149,7 +153,7 @@ class ToctreeTransforms(SphinxPostTransform):
             return False
 
         docname = self.document["source"]
-        if getFilename(docname) == self.app.config.master_doc:
+        if getRelativeFilename(docname, 0) == self.app.config.master_doc:
             TOC_PATH = Path(self.app.confdir).joinpath("_toc.yml")
             tocfile = yaml.safe_load(TOC_PATH.read_text("utf8"))
 

--- a/jupyterbook_latex/utils.py
+++ b/jupyterbook_latex/utils.py
@@ -5,10 +5,10 @@ def removeExtension(filename):
     return filename
 
 
-def getRelativeFilename(source, slashes):
-    """gets the filename along with the path upto the number of slashes.
+def getFilenameWithSubpath(source, slashes):
+    """Gets the filename along with the relative path upto the number of slashes.
     :param source: full source path
-    :param slashes: slashes denote the level of subpath
+    :param slashes: denotes the level of subpath
     """
     filename = ""
     original = str(source)

--- a/jupyterbook_latex/utils.py
+++ b/jupyterbook_latex/utils.py
@@ -1,16 +1,30 @@
-from pathlib import Path
-
-
-def getFilename(source):
-    name = Path(source).stem
-    return name
-
-
 def removeExtension(filename):
     index = filename.find(".")
     if index > 0:
         filename = filename[0:index]
     return filename
+
+
+def getRelativeFilename(source, slashes):
+    """gets the filename along with the path upto the number of slashes.
+    :param source: full source path
+    :param slashes: slashes denote the level of subpath
+    """
+    filename = ""
+    original = str(source)
+
+    while slashes >= 0:
+        index = original.rfind("/")
+        if index == -1:
+            return filename
+        filename = original[index:] + filename
+        original = original[:index]
+        slashes -= 1
+
+    if filename[0] == "/":
+        filename = filename[1:]
+
+    return removeExtension(filename)
 
 
 def sphinxEncode(string):


### PR DESCRIPTION
This PR handles master_doc being inside a subdirectory relative to `_toc.yml`. The presence of which was hampering tableofcontents generation for pdf builds.

An example master_doc entry which this PR handles:

```
- file: content/preface
```