### PR TITLE
👌 IMPROVE: Extension loading message

### DIFF
--- a/jupyterbook_latex/__init__.py
+++ b/jupyterbook_latex/__init__.py
@@ -34,6 +34,8 @@ def skip(self, node):
 
 
 def build_init_handler(app):
+    from sphinx.util.console import bold
+
     # only allow latex builder to access rest of the features
     if isinstance(app.builder, builders.latex.LaTeXBuilder):
         app.add_post_transform(codeCellTransforms)
@@ -49,6 +51,11 @@ def build_init_handler(app):
         app.add_transform(LatexMasterDocTransforms)
         app.add_post_transform(ToctreeTransforms)
         app.add_post_transform(handleSubSections)
+        logger.info(
+            bold("jupyterbook-latex v%s:") + "(latex_engine='%s')",
+            __version__,
+            app.config["latex_engine"],
+        )
 
 
 def add_necessary_config(app, config):


### PR DESCRIPTION
Have logged a message in the console stating the version and the latex_engine, for better visibility of this extension.

The message looks like the following:

<img width="369" alt="Screen Shot 2021-03-01 at 12 23 13 pm" src="https://user-images.githubusercontent.com/6542997/109441261-e7ead580-7a88-11eb-8a21-95d4993b712a.png">
