### PR TITLE
MAINT: Update sphinx-external-toc version pinning to be a range

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ testing =
     pytest-cov~=2.8
     pytest-regressions
     sphinx-external-toc>=0.1.0,<0.3.0
-    sphinxcontrib-bibtex~=2.2.1
+    sphinxcontrib-bibtex>=2.2.1,<2.3.0
     texsoup
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ testing =
     pytest>=3.6,<4
     pytest-cov~=2.8
     pytest-regressions
-    sphinx-external-toc~=0.1.0
+    sphinx-external-toc>=0.1.0,<0.3.0
     sphinxcontrib-bibtex~=2.2.0
     texsoup
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ testing =
     pytest-cov~=2.8
     pytest-regressions
     sphinx-external-toc>=0.1.0,<0.3.0
-    sphinxcontrib-bibtex~=2.2.0
+    sphinxcontrib-bibtex~=2.2.1
     texsoup
 
 [options.packages.find]

--- a/tests/test_jupyter_book/test_toc.tex
+++ b/tests/test_jupyter_book/test_toc.tex
@@ -50,7 +50,7 @@ Chap 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
 \sphinxAtStartPar
 
 
-\sphinxAtStartPar{[}\sphinxcite{part1/chap2:id5}, \sphinxcite{part1/chap2:id3}, \sphinxcite{part1/chap2:id2}, \sphinxcite{part1/chap2:id4}{]}
+\sphinxAtStartPar{[}\hyperlink{cite.part1/chap2:id5}{CKS+10}, \hyperlink{cite.part1/chap2:id3}{HdHP+16}, \hyperlink{cite.part1/chap2:id2}{PGH11}, \hyperlink{cite.part1/chap2:id4}{SK14}{]}
 
 
 \section{Section 1}

--- a/tests/test_jupyter_book/test_toc.tex
+++ b/tests/test_jupyter_book/test_toc.tex
@@ -50,7 +50,7 @@ Chap 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
 \sphinxAtStartPar
 
 
-\sphinxAtStartPar{[}\hyperlink{cite.part1/chap2:id5}{CKS+10}, \hyperlink{cite.part1/chap2:id3}{HdHP+16}, \hyperlink{cite.part1/chap2:id2}{PGH11}, \hyperlink{cite.part1/chap2:id4}{SK14}{]}
+\sphinxAtStartPar{[}\sphinxcite{part1/chap2:id5}, \sphinxcite{part1/chap2:id3}, \sphinxcite{part1/chap2:id2}, \sphinxcite{part1/chap2:id4}{]}
 
 
 \section{Section 1}

--- a/tests/test_sphinx/test_build_no_ext.resolved.xml
+++ b/tests/test_sphinx/test_build_no_ext.resolved.xml
@@ -26,21 +26,17 @@
                         <paragraph>
                             <inline ids="id6">
                                 [
-                                <raw_latex xml:space="preserve">
-                                CKS+10
-                                <raw_latex xml:space="preserve">
+                                <citation_reference docname="part1/chap2" refname="id5">
+                                    CKS+10
                                 , 
-                                <raw_latex xml:space="preserve">
-                                HdHP+16
-                                <raw_latex xml:space="preserve">
+                                <citation_reference docname="part1/chap2" refname="id3">
+                                    HdHP+16
                                 , 
-                                <raw_latex xml:space="preserve">
-                                PGH11
-                                <raw_latex xml:space="preserve">
+                                <citation_reference docname="part1/chap2" refname="id2">
+                                    PGH11
                                 , 
-                                <raw_latex xml:space="preserve">
-                                SK14
-                                <raw_latex xml:space="preserve">
+                                <citation_reference docname="part1/chap2" refname="id4">
+                                    SK14
                                 ]
                         <compound classes="toctree-wrapper">
                             <start_of_file docname="part1/sec1">

--- a/tests/test_sphinx/test_build_no_ext.resolved.xml
+++ b/tests/test_sphinx/test_build_no_ext.resolved.xml
@@ -26,17 +26,21 @@
                         <paragraph>
                             <inline ids="id6">
                                 [
-                                <citation_reference docname="part1/chap2" refname="id5">
-                                    CKS+10
+                                <raw_latex xml:space="preserve">
+                                CKS+10
+                                <raw_latex xml:space="preserve">
                                 , 
-                                <citation_reference docname="part1/chap2" refname="id3">
-                                    HdHP+16
+                                <raw_latex xml:space="preserve">
+                                HdHP+16
+                                <raw_latex xml:space="preserve">
                                 , 
-                                <citation_reference docname="part1/chap2" refname="id2">
-                                    PGH11
+                                <raw_latex xml:space="preserve">
+                                PGH11
+                                <raw_latex xml:space="preserve">
                                 , 
-                                <citation_reference docname="part1/chap2" refname="id4">
-                                    SK14
+                                <raw_latex xml:space="preserve">
+                                SK14
+                                <raw_latex xml:space="preserve">
                                 ]
                         <compound classes="toctree-wrapper">
                             <start_of_file docname="part1/sec1">

--- a/tests/test_sphinx/test_build_no_ext.tex
+++ b/tests/test_sphinx/test_build_no_ext.tex
@@ -32,7 +32,7 @@ Chap 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
 \sphinxAtStartPar
 
 
-\sphinxAtStartPar{[}\sphinxcite{part1/chap2:id5}, \sphinxcite{part1/chap2:id3}, \sphinxcite{part1/chap2:id2}, \sphinxcite{part1/chap2:id4}{]}
+\sphinxAtStartPar{[}\hyperlink{cite.part1/chap2:id5}{CKS+10}, \hyperlink{cite.part1/chap2:id3}{HdHP+16}, \hyperlink{cite.part1/chap2:id2}{PGH11}, \hyperlink{cite.part1/chap2:id4}{SK14}{]}
 
 
 \subsection{Section 1}

--- a/tests/test_sphinx/test_build_no_ext.tex
+++ b/tests/test_sphinx/test_build_no_ext.tex
@@ -32,7 +32,7 @@ Chap 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
 \sphinxAtStartPar
 
 
-\sphinxAtStartPar{[}\hyperlink{cite.part1/chap2:id5}{CKS+10}, \hyperlink{cite.part1/chap2:id3}{HdHP+16}, \hyperlink{cite.part1/chap2:id2}{PGH11}, \hyperlink{cite.part1/chap2:id4}{SK14}{]}
+\sphinxAtStartPar{[}\sphinxcite{part1/chap2:id5}, \sphinxcite{part1/chap2:id3}, \sphinxcite{part1/chap2:id2}, \sphinxcite{part1/chap2:id4}{]}
 
 
 \subsection{Section 1}

--- a/tests/test_sphinx/test_build_with_ext.resolved.xml
+++ b/tests/test_sphinx/test_build_with_ext.resolved.xml
@@ -45,17 +45,21 @@
                             <paragraph>
                                 <inline ids="id6">
                                     [
-                                    <citation_reference docname="part1/chap2" refname="id5">
-                                        CKS+10
+                                    <raw_latex xml:space="preserve">
+                                    CKS+10
+                                    <raw_latex xml:space="preserve">
                                     , 
-                                    <citation_reference docname="part1/chap2" refname="id3">
-                                        HdHP+16
+                                    <raw_latex xml:space="preserve">
+                                    HdHP+16
+                                    <raw_latex xml:space="preserve">
                                     , 
-                                    <citation_reference docname="part1/chap2" refname="id2">
-                                        PGH11
+                                    <raw_latex xml:space="preserve">
+                                    PGH11
+                                    <raw_latex xml:space="preserve">
                                     , 
-                                    <citation_reference docname="part1/chap2" refname="id4">
-                                        SK14
+                                    <raw_latex xml:space="preserve">
+                                    SK14
+                                    <raw_latex xml:space="preserve">
                                     ]
                             <HiddenCellNode classes="toctree-wrapper">
                             <compound classes="toctree-wrapper">

--- a/tests/test_sphinx/test_build_with_ext.resolved.xml
+++ b/tests/test_sphinx/test_build_with_ext.resolved.xml
@@ -45,21 +45,17 @@
                             <paragraph>
                                 <inline ids="id6">
                                     [
-                                    <raw_latex xml:space="preserve">
-                                    CKS+10
-                                    <raw_latex xml:space="preserve">
+                                    <citation_reference docname="part1/chap2" refname="id5">
+                                        CKS+10
                                     , 
-                                    <raw_latex xml:space="preserve">
-                                    HdHP+16
-                                    <raw_latex xml:space="preserve">
+                                    <citation_reference docname="part1/chap2" refname="id3">
+                                        HdHP+16
                                     , 
-                                    <raw_latex xml:space="preserve">
-                                    PGH11
-                                    <raw_latex xml:space="preserve">
+                                    <citation_reference docname="part1/chap2" refname="id2">
+                                        PGH11
                                     , 
-                                    <raw_latex xml:space="preserve">
-                                    SK14
-                                    <raw_latex xml:space="preserve">
+                                    <citation_reference docname="part1/chap2" refname="id4">
+                                        SK14
                                     ]
                             <HiddenCellNode classes="toctree-wrapper">
                             <compound classes="toctree-wrapper">

--- a/tests/test_sphinx/test_build_with_ext.tex
+++ b/tests/test_sphinx/test_build_with_ext.tex
@@ -50,7 +50,7 @@ Chap 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
 \sphinxAtStartPar
 
 
-\sphinxAtStartPar{[}\sphinxcite{part1/chap2:id5}, \sphinxcite{part1/chap2:id3}, \sphinxcite{part1/chap2:id2}, \sphinxcite{part1/chap2:id4}{]}
+\sphinxAtStartPar{[}\hyperlink{cite.part1/chap2:id5}{CKS+10}, \hyperlink{cite.part1/chap2:id3}{HdHP+16}, \hyperlink{cite.part1/chap2:id2}{PGH11}, \hyperlink{cite.part1/chap2:id4}{SK14}{]}
 
 
 \section{Section 1}

--- a/tests/test_sphinx/test_build_with_ext.tex
+++ b/tests/test_sphinx/test_build_with_ext.tex
@@ -50,7 +50,7 @@ Chap 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit. In dapibus.
 \sphinxAtStartPar
 
 
-\sphinxAtStartPar{[}\hyperlink{cite.part1/chap2:id5}{CKS+10}, \hyperlink{cite.part1/chap2:id3}{HdHP+16}, \hyperlink{cite.part1/chap2:id2}{PGH11}, \hyperlink{cite.part1/chap2:id4}{SK14}{]}
+\sphinxAtStartPar{[}\sphinxcite{part1/chap2:id5}, \sphinxcite{part1/chap2:id3}, \sphinxcite{part1/chap2:id2}, \sphinxcite{part1/chap2:id4}{]}
 
 
 \section{Section 1}


### PR DESCRIPTION
This looks to address https://github.com/executablebooks/jupyter-book/pull/1321 and #59 (a circular dependency)

This PR also updates fixtures which I presume have changed due to an update in `sphinx` 
@AakashGfude can we review these file regressions?

- [x] check file regression updates from latest test sets

