### PR TITLE
🚀 RELEASE: 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 0.3.1 - 2021-06-01
+
+This is a **minor** release to increase the flexibility for installation requirements
+
+### Maintenance
+
+- Updated [version pinning](https://github.com/executablebooks/jupyterbook-latex/pull/60) for
+  `sphinx-external-toc` and `sphinxcontrib-bibtex`
+
+
 ## 0.3.0 - 2021-05-05
 
 This release essentially re-writes the most of the code to:

--- a/jupyterbook_latex/__init__.py
+++ b/jupyterbook_latex/__init__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 """jupyterbook-latex version"""
 
 


### PR DESCRIPTION
This PR sets up `jupyterbook-latex==0.3.1` as a minor maintenance release for increase flexibility in version pins on dependencies